### PR TITLE
Make meta path overridable

### DIFF
--- a/gcp/samples/ad-on-gcp/main.tf
+++ b/gcp/samples/ad-on-gcp/main.tf
@@ -154,6 +154,7 @@ resource "google_compute_instance" "dc" {
         nameHost = "dc", 
         nameDomain = var.name-domain,
         nameConfiguration = "ad",
+        uriMeta = var.uri-meta,
         uriConfigurations = var.uri-configurations,
         password = var.password 
       })
@@ -187,6 +188,7 @@ resource "google_compute_instance" "jumpy" {
       nameHost = "jumpy", 
       nameDomain = var.name-domain,
       nameConfiguration = "jumpy",
+      uriMeta = var.uri-meta,
       uriConfigurations = var.uri-configurations,
       password = var.password 
     })

--- a/gcp/samples/ad-on-gcp/specialize.ps1
+++ b/gcp/samples/ad-on-gcp/specialize.ps1
@@ -7,6 +7,7 @@ $DebugPreference = "SilentlyContinue";
 $nameHost = '${nameHost}';
 $nameDomain = '${nameDomain}';
 $nameConfiguration = '${nameConfiguration}';
+$uriMeta = '${uriMeta}';
 $uriConfigurations = '${uriConfigurations}';
 $password = '${password}';
 $passwordSecure = ConvertTo-SecureString -String $password -AsPlainText -Force;
@@ -68,7 +69,7 @@ foreach($module in $modules)
 # Download DSC (meta) configuration
 $pathDscConfigrationDefinitionMeta = (Join-Path -Path $env:TEMP -ChildPath "meta.ps1");
 $pathDscConfigrationDefinition = (Join-Path -Path $env:TEMP -ChildPath "$nameConfiguration.ps1");
-Invoke-WebRequest -Uri "$uriConfigurations/meta.ps1" -OutFile $pathDscConfigrationDefinitionMeta;
+Invoke-WebRequest -Uri "$uriMeta/meta.ps1" -OutFile $pathDscConfigrationDefinitionMeta;
 Invoke-WebRequest -Uri "$uriConfigurations/$nameConfiguration.ps1" -OutFile $pathDscConfigrationDefinition;
 
 # Source DSC (meta) configuration

--- a/gcp/samples/ad-on-gcp/variables.tf
+++ b/gcp/samples/ad-on-gcp/variables.tf
@@ -15,6 +15,10 @@ variable "name-domain" {
 variable "password" {
 }
 
+variable "uri-meta" {
+  default = "https://raw.githubusercontent.com/peterschen/blog/master/gcp/samples/ad-on-gcp"
+}
+
 variable "uri-configurations" {
   default = "https://raw.githubusercontent.com/peterschen/blog/master/gcp/samples/ad-on-gcp"
 }


### PR DESCRIPTION
This PR split DSC meta and configuration URIs to enable having them at separate locations.