### PR TITLE
Fixed counter

### DIFF
--- a/gcp/samples/ad-on-gcp/main.tf
+++ b/gcp/samples/ad-on-gcp/main.tf
@@ -34,7 +34,7 @@ resource "google_compute_network" "network" {
 }
 
 resource "google_compute_subnetwork" "subnets" {
-  count = length(var.zones)
+  count = length(var.regions)
   region = var.regions[count.index]
   name = var.regions[count.index]
   ip_cidr_range = local.network-ranges[count.index]


### PR DESCRIPTION
This PR fixes a problem where the zones list is used as the count indicator for creating subnets. When used as a module more zones might be passed and this breaks deployment.