### PR TITLE
Add sofs-on-gcp

### DIFF
--- a/gcp/samples/sofs-on-gcp/main.tf
+++ b/gcp/samples/sofs-on-gcp/main.tf
@@ -27,6 +27,7 @@ resource "google_compute_address" "sofs-cl" {
   name = "sofs-cl"
   address_type = "INTERNAL"
   subnetwork = module.ad-on-gcp.subnets[0]
+  depends_on = [module.ad-on-gcp]
 }
 
 resource "google_compute_instance" "sofs" {

--- a/gcp/samples/sofs-on-gcp/main.tf
+++ b/gcp/samples/sofs-on-gcp/main.tf
@@ -22,6 +22,21 @@ module "ad-on-gcp" {
   password = var.password
 }
 
+resource "google_compute_firewall" "allow-lbhealthcheck-gcp" {
+  name    = "allow-lbhealthcheck-gcp"
+  network = module.ad-on-gcp.network
+  priority = 5000
+
+  allow {
+    protocol = "tcp"
+    ports    = ["59998"]
+  }
+
+  direction = "INGRESS"
+
+  source_ranges = ["35.191.0.0/16", "130.211.0.0/22"]
+}
+
 resource "google_compute_address" "sofs-cl" {
   region = var.regions[0]
   name = "sofs-cl"
@@ -52,6 +67,7 @@ resource "google_compute_instance" "sofs" {
   metadata = {
     sample = local.name-sample
     type = "sofs"
+    enable-wsfc = "true"
     sysprep-specialize-script-ps1 = templatefile("${module.ad-on-gcp.path-module}/specialize.ps1", { 
         nameHost = "sofs-${count.index}", 
         nameConfiguration = "sofs",

--- a/gcp/samples/sofs-on-gcp/main.tf
+++ b/gcp/samples/sofs-on-gcp/main.tf
@@ -10,10 +10,8 @@ provider "google-beta" {
 
 locals {
   name-sample = "sofs-on-gcp"
-  #count-instances = 3
+  count-instances = 3
 }
-
-data "google_client_config" "current" {}
 
 module "ad-on-gcp" {
   source = "github.com/peterschen/blog/gcp/samples/ad-on-gcp"
@@ -25,7 +23,7 @@ module "ad-on-gcp" {
 }
 
 resource "google_compute_instance" "sofs" {
-  count = 3
+  count = local.count-instances
   zone = "${var.regions[0]}-${var.zones[count.index]}"
   name = "sofs-${count.index}"
   machine_type = "n1-standard-2"

--- a/gcp/samples/sofs-on-gcp/main.tf
+++ b/gcp/samples/sofs-on-gcp/main.tf
@@ -24,7 +24,7 @@ module "ad-on-gcp" {
 
 resource "google_compute_instance" "sofs" {
   count = local.count-instances
-  zone = "${var.regions[0]}-${var.zones[count.index]}"
+  zone = "${var.regions[0]}-${var.zones[0][count.index]}"
   name = "sofs-${count.index}"
   machine_type = "n1-standard-2"
 

--- a/gcp/samples/sofs-on-gcp/main.tf
+++ b/gcp/samples/sofs-on-gcp/main.tf
@@ -78,6 +78,8 @@ resource "google_compute_instance" "sofs" {
         password = var.password,
         parametersConfiguration = jsonencode({
           domainName = var.name-domain,
+          nodePrefix = "sofs"
+          nodeCount = local.count-instances
           ipCluster = google_compute_address.sofs-cl.address,
           isFirst = (count.index == 0)
         })

--- a/gcp/samples/sofs-on-gcp/outputs.tf
+++ b/gcp/samples/sofs-on-gcp/outputs.tf
@@ -1,0 +1,11 @@
+output "path-module" {
+  value = path.module
+}
+
+output "network" {
+  value = module.ad-on-gcp.network
+}
+
+output "subnets" {
+  value = module.ad-on-gcp.subnets
+}

--- a/gcp/samples/sofs-on-gcp/sofs.ps1
+++ b/gcp/samples/sofs-on-gcp/sofs.ps1
@@ -13,7 +13,7 @@ configuration ConfigurationWorkload
     );
 
     Import-DscResource -ModuleName PSDesiredStateConfiguration, 
-        ComputerManagementDsc, xActiveDirectory, NetworkingDsc, xFailOverCluster;
+        ComputerManagementDsc, ActiveDirectoryDsc, NetworkingDsc, xFailOverCluster;
 
     $features = @(
         "Failover-clustering",
@@ -77,12 +77,11 @@ configuration ConfigurationWorkload
             Description = "Enables GCP Internal Load Balancer to check which node in the cluster is active to route traffic to the cluster IP."
         }
 
-        xWaitForADDomain "WFAD"
+        WaitForADDomain "WFAD"
         {
             DomainName  = $($Parameters.domainName)
-            RetryIntervalSec = 300
-            RebootRetryCount = 2
-            DomainUserCredential = $credentialAdminDomain
+            Credential = $credentialAdminDomain
+            RestartCount = 2
         }
 
         Computer "JoinDomain"
@@ -90,7 +89,7 @@ configuration ConfigurationWorkload
             Name = $Node.NodeName
             DomainName = $($Parameters.domainName)
             Credential = $credentialAdminDomain
-            DependsOn = "[xWaitForADDomain]WFAD"
+            DependsOn = "[WaitForADDomain]WFAD"
         }
 
         Group "G-Administrators"

--- a/gcp/samples/sofs-on-gcp/sofs.ps1
+++ b/gcp/samples/sofs-on-gcp/sofs.ps1
@@ -131,6 +131,7 @@ configuration ConfigurationWorkload
             xWaitForCluster "WFC-sofs-cl"
             {
                 Name = "sofs-cl"
+                DomainAdministratorCredential = $credentialAdminDomain
                 RetryIntervalSec = 10
                 RetryCount = 60
                 DependsOn = '[WindowsFeature]WF-Failover-clustering'

--- a/gcp/samples/sofs-on-gcp/sofs.ps1
+++ b/gcp/samples/sofs-on-gcp/sofs.ps1
@@ -131,7 +131,6 @@ configuration ConfigurationWorkload
             xWaitForCluster "WFC-sofs-cl"
             {
                 Name = "sofs-cl"
-                DomainAdministratorCredential = $credentialAdminDomain
                 RetryIntervalSec = 10
                 RetryCount = 60
                 DependsOn = '[WindowsFeature]WF-Failover-clustering'
@@ -140,7 +139,7 @@ configuration ConfigurationWorkload
             xCluster JoinSecondNodeToCluster
             {
                 Name = "sofs-cl"
-                DomainAdministratorCredential = $domainCredential
+                DomainAdministratorCredential = $credentialAdminDomain
                 DependsOn = '[xWaitForCluster]WFC-sofs-cl'
             }
         }

--- a/gcp/samples/sofs-on-gcp/sofs.ps1
+++ b/gcp/samples/sofs-on-gcp/sofs.ps1
@@ -18,7 +18,9 @@ configuration ConfigurationWorkload
     $features = @(
         "Failover-clustering",
         "FS-FileServer",
-        "Storage-Replica"
+        "Storage-Replica",
+        "RSAT-Clustering-PowerShell",
+        "RSAT-Storage-Replica"
     );
 
     $rules = @(

--- a/gcp/samples/sofs-on-gcp/sofs.ps1
+++ b/gcp/samples/sofs-on-gcp/sofs.ps1
@@ -120,10 +120,17 @@ configuration ConfigurationWorkload
         {
             xCluster CreateCluster
             {
-                Name = 'sofs-cl'
+                Name = "sofs-cl"
                 DomainAdministratorCredential = $credentialAdminDomain
                 StaticIPAddress = $Parameters.ipCluster
-                DependsOn = '[WindowsFeature]WF-Failover-clustering'
+                DependsOn = "[WindowsFeature]WF-Failover-clustering"
+            }
+
+            xClusterQuorum Quorum
+            {
+                Type = "NodeMajority"
+                IsSingleInstance = "Yes"
+                DependsOn = "[xCluster]CreateCluster"
             }
         }
         else
@@ -133,14 +140,14 @@ configuration ConfigurationWorkload
                 Name = "sofs-cl"
                 RetryIntervalSec = 10
                 RetryCount = 60
-                DependsOn = '[WindowsFeature]WF-Failover-clustering'
+                DependsOn = "[WindowsFeature]WF-Failover-clustering"
             }
 
             xCluster JoinSecondNodeToCluster
             {
                 Name = "sofs-cl"
                 DomainAdministratorCredential = $credentialAdminDomain
-                DependsOn = '[xWaitForCluster]WFC-sofs-cl'
+                DependsOn = "[xWaitForCluster]WFC-sofs-cl"
             }
         }
     }

--- a/gcp/samples/sofs-on-gcp/sofs.ps1
+++ b/gcp/samples/sofs-on-gcp/sofs.ps1
@@ -109,6 +109,7 @@ configuration ConfigurationWorkload
             {
                 Name = 'sofs-cl'
                 DomainAdministratorCredential = $credentialAdminDomain
+                StaticIPAddress = $Parameters.ipCluster
                 DependsOn = '[WindowsFeature]WF-Failover-clustering'
             }
         }

--- a/gcp/samples/sofs-on-gcp/sofs.ps1
+++ b/gcp/samples/sofs-on-gcp/sofs.ps1
@@ -13,7 +13,7 @@ configuration ConfigurationWorkload
     );
 
     Import-DscResource -ModuleName PSDesiredStateConfiguration, 
-        ComputerManagementDsc, xActiveDirectory, xFailOverCluster;
+        ComputerManagementDsc, xActiveDirectory, NetworkingDsc, xFailOverCluster;
 
     $features = @(
         "Failover-clustering",

--- a/gcp/samples/sofs-on-gcp/sofs.ps1
+++ b/gcp/samples/sofs-on-gcp/sofs.ps1
@@ -67,7 +67,6 @@ configuration ConfigurationWorkload
         {
             Name = "GceClusterHelper"
             DisplayName = "GCE Cluster helper"
-            Group = "sofs-on-ad"
             Ensure = "Present"
             Enabled = "True"
             Direction = "InBound"

--- a/gcp/samples/sofs-on-gcp/sofs.ps1
+++ b/gcp/samples/sofs-on-gcp/sofs.ps1
@@ -63,6 +63,19 @@ configuration ConfigurationWorkload
             }
         }
 
+        Firewall "F-GceClusterHelper"
+        {
+            Name = "GceClusterHelper"
+            DisplayName = "GCE Cluster helper"
+            Group = "sofs-on-ad"
+            Ensure = "Present"
+            Enabled = "True"
+            Direction = "InBound"
+            LocalPort = ("59998")
+            Protocol = "TCP"
+            Description = "Enables GCP Internal Load Balancer to check which node in the cluster is active to route traffic to the cluster IP."
+        }
+
         xWaitForADDomain "WFAD"
         {
             DomainName  = $($Parameters.domainName)

--- a/gcp/samples/sofs-on-gcp/variables.tf
+++ b/gcp/samples/sofs-on-gcp/variables.tf
@@ -2,11 +2,16 @@ variable "project" {
 }
 
 variable "regions" {
-  type = "list"
+  type = list(string)
+  default = ["europe-west1", "europe-west4"]
 }
 
 variable "zones" {
-  type = "list"
+  type = list(list(string))
+  default = [
+    ["b", "c", "d"],
+    ["a", "b", "c"]
+  ]
 }
 
 variable "name-domain" {

--- a/gcp/samples/sofs-on-gcp/variables.tf
+++ b/gcp/samples/sofs-on-gcp/variables.tf
@@ -27,3 +27,8 @@ variable "uri-meta" {
 variable "uri-configurations" {
   default = "https://raw.githubusercontent.com/peterschen/blog/master/gcp/samples/sofs-on-gcp"
 }
+
+variable "provision-cluster" {
+  type = bool
+  default = true
+}


### PR DESCRIPTION
This PR adds the sofs-on-gcp example - an end-to-end solution building a S2D/SOFS cluster on GCP by using Terraform.