### PR TITLE
Added ignore_changes meta config for attached_disk

### DIFF
--- a/gcp/samples/sofs-on-gcp/main.tf
+++ b/gcp/samples/sofs-on-gcp/main.tf
@@ -86,6 +86,10 @@ resource "google_compute_instance" "sofs" {
         })
       })
   }
+
+  lifecycle {
+    ignore_changes = [attached_disk]
+  }
 }
 
 resource "google_compute_disk" "sofs-disks" {


### PR DESCRIPTION
This PR adds the ignore_changes lifecycle meta config to ignore subsequently attached disks which leads to race conditions and broken idempotency.