### PR TITLE
Add service account

### DIFF
--- a/gcp/samples/ad-on-gcp/main.tf
+++ b/gcp/samples/ad-on-gcp/main.tf
@@ -11,6 +11,7 @@ provider "google-beta" {
 locals {
   name-sample = "ad-on-gce"
   apis = ["cloudresourcemanager.googleapis.com", "compute.googleapis.com", "dns.googleapis.com"]
+  scopes-default = ["storage-ro", "logging-write", "monitoring-write", "service-control", "service-management", "pubsub", "https://www.googleapis.com/auth/trace.append"]
   network-prefixes = ["10.0.0", "10.1.0"]
   network-mask = "16"
   network-ranges = ["${local.network-prefixes[0]}.0/${local.network-mask}", "${local.network-prefixes[1]}.0/${local.network-mask}"]
@@ -170,6 +171,10 @@ resource "google_compute_instance" "dc" {
       })
   }
 
+  service_account {
+    scopes = local.scopes-default
+  }
+
   depends_on = ["google_project_service.apis"]
 }
 
@@ -205,6 +210,10 @@ resource "google_compute_instance" "jumpy" {
         domainName = var.name-domain
       })
     })
+  }
+
+  service_account {
+    scopes = local.scopes-default
   }
 
   depends_on = ["google_project_service.apis"]

--- a/gcp/samples/sofs-on-gcp/main.tf
+++ b/gcp/samples/sofs-on-gcp/main.tf
@@ -10,6 +10,7 @@ provider "google-beta" {
 
 locals {
   name-sample = "sofs-on-gcp"
+  scopes-default = ["storage-ro", "logging-write", "monitoring-write", "service-control", "service-management", "pubsub", "https://www.googleapis.com/auth/trace.append"]
   count-nodes = 3
   count-disks = 4
   size-disks = 100
@@ -85,6 +86,10 @@ resource "google_compute_instance" "sofs" {
           isFirst = (count.index == 0)
         })
       })
+  }
+
+  service_account {
+    scopes = local.scopes-default
   }
 
   lifecycle {


### PR DESCRIPTION
This PR adds the default GCE service account with the [default scopes](https://cloud.google.com/sdk/gcloud/reference/alpha/compute/instances/set-scopes#--scopes) to `ad-on-gcp` and `sofs-on-gcp`.