### PR TITLE
Change SA scopes to cloud-platform

### DIFF
--- a/gcp/samples/ad-on-gcp/main.tf
+++ b/gcp/samples/ad-on-gcp/main.tf
@@ -11,7 +11,7 @@ provider "google-beta" {
 locals {
   name-sample = "ad-on-gce"
   apis = ["cloudresourcemanager.googleapis.com", "compute.googleapis.com", "dns.googleapis.com"]
-  scopes-default = ["storage-ro", "logging-write", "monitoring-write", "service-control", "service-management", "pubsub", "https://www.googleapis.com/auth/trace.append"]
+  scopes-default = ["https://www.googleapis.com/auth/cloud-platform"]
   network-prefixes = ["10.0.0", "10.1.0"]
   network-mask = "16"
   network-ranges = ["${local.network-prefixes[0]}.0/${local.network-mask}", "${local.network-prefixes[1]}.0/${local.network-mask}"]

--- a/gcp/samples/sofs-on-gcp/main.tf
+++ b/gcp/samples/sofs-on-gcp/main.tf
@@ -10,7 +10,7 @@ provider "google-beta" {
 
 locals {
   name-sample = "sofs-on-gcp"
-  scopes-default = ["storage-ro", "logging-write", "monitoring-write", "service-control", "service-management", "pubsub", "https://www.googleapis.com/auth/trace.append"]
+  scopes-default = ["https://www.googleapis.com/auth/cloud-platform"]
   count-nodes = 3
   count-disks = 4
   size-disks = 100


### PR DESCRIPTION
This PR changes the default scopes for instances to `cloud-platform`. This allows the instance to access all APIs and can be further scoped by IAM role assignment to the default GCE service account.