### PR TITLE
Encrypt credentials in compiled DSC configuration (.mof)

### DIFF
--- a/gcp/samples/ad-on-gcp/meta.ps1
+++ b/gcp/samples/ad-on-gcp/meta.ps1
@@ -4,7 +4,10 @@ configuration ConfigurationMeta
     param
     (
         [ValidateNotNullOrEmpty()] 
-        [string] $ComputerName
+        [string] $ComputerName,
+
+        [ValidateNotNullOrEmpty()] 
+        [string] $Thumbprint
     );
 
     Node $ComputerName
@@ -17,6 +20,7 @@ configuration ConfigurationMeta
             ActionAfterReboot = "ContinueConfiguration"
             RefreshMode = "Push"
             DebugMode = "All"
+            CertificateId = $Thumbprint
         }
     }
 }


### PR DESCRIPTION
This PR adds encryption to the compiled DSC configuration. During [specialize phase](https://cloud.google.com/compute/docs/startupscript#providing_a_startup_script_for_windows_instances) a self-signed certificate is created on each node which in turn is used to encrypt the .mof. This protects any provided credentials on disk. 