### PR TITLE
Add documentation for sofs-on-gcp

### DIFF
--- a/gcp/samples/sofs-on-gcp/README.md
+++ b/gcp/samples/sofs-on-gcp/README.md
@@ -40,9 +40,9 @@ terraform destroy -var="project=$PROJECT" -var="name-domain=$DOMAIN" -var="passw
 If you need to redeploy the VM instances you need to taint them first. You may need to do this if you have changed the DSC configuration which does not invalidate the Terraform state.
 
 ```
-terraform taint module.ad-on-gcp.google_compute_instance.jumpy
 terraform taint module.ad-on-gcp.google_compute_instance.dc\[0\]
 terraform taint module.ad-on-gcp.google_compute_instance.dc\[1\]
+terraform taint module.ad-on-gcp.google_compute_instance.jumpy
 terraform taint google_compute_instance.sofs\[0\]
 terraform taint google_compute_instance.sofs\[1\]
 terraform taint google_compute_instance.sofs\[2\]

--- a/gcp/samples/sofs-on-gcp/README.md
+++ b/gcp/samples/sofs-on-gcp/README.md
@@ -10,6 +10,14 @@ export SA_KEY_FILE=~configs/sa/terraform@cbp-sofs.json # Set to the Service Acco
 export PASSWORD="Admin123Admin123" # Set to the desired password
 export DOMAIN="sofs.lab" # Set to the desired domain name
 
+# By default only SSD Persistent Disks are deployed with the machine. 
+# You can enable the deployment of Standard Persistent Disks as well which will enable tiering in Scale-out File Server.
+export PROVISION_HDD=false
+
+# By default Windows Server Failover Clustering (WSFC) will not be provisioned automatically.
+# You can enable automatic deployment which will enable WSFC, S2D and SOFS
+export PROVISION_CLUSTER=false
+
 export GOOGLE_APPLICATION_CREDENTIALS=$SA_KEY_FILE
 gcloud auth activate-service-account --key-file=$SA_KEY_FILE
 gcloud config set project $PROJECT
@@ -20,13 +28,14 @@ terraform get -update
 
 ## Deploy resource ##
 ```
-terraform apply -var="project=$PROJECT" -var="name-domain=$DOMAIN" -var="password=$PASSWORD"
+terraform apply -var "project=$PROJECT" -var "name-domain=$DOMAIN" -var "password=$PASSWORD" -var "provision-hdd=$PROVISION_HDD" -var "provision-cluster=$PROVISION_CLUSTER"
 ```
 
 ## Destroy resources ##
 ```
 terraform destroy -var="project=$PROJECT" -var="name-domain=$DOMAIN" -var="password=$PASSWORD"
 ```
+
 ## Redeploy ##
 If you need to redeploy the VM instances you need to taint them first. You may need to do this if you have changed the DSC configuration which does not invalidate the Terraform state.
 

--- a/gcp/samples/sofs-on-gcp/README.md
+++ b/gcp/samples/sofs-on-gcp/README.md
@@ -1,4 +1,34 @@
 # SOFS on GCP #
+This sample deploys a Scale-out File Server on Google Cloud. It relies on the `ad-on-gcp` sample. This sample is very opinionated and only leaves a few parameters to configure. It is meant for rapid deployment for development environments to validate capabilities or test things out.
+
+## Configure environment ##
+These instructions work for Linux, macOS and Cloud Shell. For Windows you may need to adapt these instructions.
+
+```
+export PROJECT=$GOOGLE_CLOUD_PROJECT # Set to proper project name if not using Cloud Shell
+export SA_KEY_FILE=~configs/sa/terraform@cbp-sofs.json # Set to the Service Account file
+export PASSWORD="Admin123Admin123" # Set to the desired password
+export DOMAIN="sofs.lab" # Set to the desired domain name
+
+export GOOGLE_APPLICATION_CREDENTIALS=$SA_KEY_FILE
+gcloud auth activate-service-account --key-file=$SA_KEY_FILE
+gcloud config set project $PROJECT
+
+terraform init
+terraform get -update
+```
+
+## Deploy resource ##
+```
+terraform apply -var="project=$PROJECT" -var="name-domain=$DOMAIN" -var="password=$PASSWORD"
+```
+
+## Destroy resources ##
+```
+terraform destroy -var="project=$PROJECT" -var="name-domain=$DOMAIN" -var="password=$PASSWORD"
+```
+## Redeploy ##
+If you need to redeploy the VM instances you need to taint them first. You may need to do this if you have changed the DSC configuration which does not invalidate the Terraform state.
 
 ```
 terraform taint module.ad-on-gcp.google_compute_instance.jumpy
@@ -7,4 +37,6 @@ terraform taint module.ad-on-gcp.google_compute_instance.dc\[1\]
 terraform taint google_compute_instance.sofs\[0\]
 terraform taint google_compute_instance.sofs\[1\]
 terraform taint google_compute_instance.sofs\[2\]
+
+terraform apply -var="project=$PROJECT" -var="name-domain=$DOMAIN" -var="password=$PASSWORD"
 ```

--- a/gcp/samples/sofs-on-gcp/README.md
+++ b/gcp/samples/sofs-on-gcp/README.md
@@ -1,5 +1,5 @@
 # SOFS on GCP #
-This sample deploys a Scale-out File Server on Google Cloud. It relies on the `ad-on-gcp` sample. This sample is very opinionated and only leaves a few parameters to configure. It is meant for rapid deployment for development environments to validate capabilities or test things out.
+This sample deploys a Scale-out File Server on Google Cloud. It relies on the [`ad-on-gcp`](../ad-on-gcp/) sample. This sample is very opinionated and only leaves a few parameters to configure. It is meant for rapid deployment for development environments to validate capabilities or test things out.
 
 ## Configure environment ##
 These instructions work for Linux, macOS and Cloud Shell. For Windows you may need to adapt these instructions.


### PR DESCRIPTION
This PR adds documentation for the `sofs-on-gcp` sample. Fixes #77.