### PR TITLE
Use self_link property for network

### DIFF
--- a/gcp/modules/cloud-nat/main.tf
+++ b/gcp/modules/cloud-nat/main.tf
@@ -12,7 +12,7 @@ resource "google_compute_router" "router" {
   project = local.project
   region = local.region
   name = "router"
-  network = local.network
+  network = local.network.self_link
 }
 
 resource "google_compute_router_nat" "nat" {


### PR DESCRIPTION
This PR aligns the `network` parameter to other modules. The module now expects a network module and not the ID to be passed.