### PR TITLE
Inline dsc config

### DIFF
--- a/gcp/modules/sysprep/specialize.ps1
+++ b/gcp/modules/sysprep/specialize.ps1
@@ -104,7 +104,7 @@ if([string]::IsNullOrEmpty($inlineConfiguration))
 }
 else
 {
-    Set-Content -Path $pathDscConfigurationDefinition -Value $inlineConfiguration;
+    [IO.File]::WriteAllBytes($pathDscConfigurationDefinition, [Convert]::FromBase64String($inlineConfiguration));
 }
 
 # Source DSC (meta) configuration


### PR DESCRIPTION
This PR adds the option to pass the DSC configuration inline to the sysprep Terraform module instead of passing a URL location. This helps for scenarios where the configuration is not externally accessible and may become the default over time.