### PR TITLE
Enable automatic domain join for bastion host

### DIFF
--- a/gcp/modules/bastion-windows/main.tf
+++ b/gcp/modules/bastion-windows/main.tf
@@ -9,6 +9,8 @@ locals {
   subnetwork = var.subnetwork
   password = var.password
   machine-type = var.machine-type
+  name-domain = var.name-domain
+  enable-domain = var.enable-domain
 }
 
 module "sysprep" {
@@ -47,7 +49,9 @@ resource "google_compute_instance" "bastion" {
       password = local.password,
       parametersConfiguration = jsonencode({
         inlineMeta = filebase64(module.sysprep.path-meta),
-        inlineConfiguration = filebase64("${path.module}/bastion.ps1")
+        inlineConfiguration = filebase64("${path.module}/bastion.ps1"),
+        nameDomain = local.name-domain,
+        enableDomain = local.enable-domain
       })
     })
   }

--- a/gcp/modules/bastion-windows/variables.tf
+++ b/gcp/modules/bastion-windows/variables.tf
@@ -20,3 +20,13 @@ variable "machine-type" {
 variable "password" {
     type = string
 }
+
+variable "name-domain" {
+    type = string
+    default = ""
+}
+
+variable "enable-domain" {
+    type = bool
+    default = false
+}


### PR DESCRIPTION
This PR enables optional automatic domain join when deploying a bastion host. 