### PR TITLE
Add missing rdp network tag

### DIFF
--- a/gcp/modules/bastion-windows/main.tf
+++ b/gcp/modules/bastion-windows/main.tf
@@ -29,7 +29,7 @@ resource "google_compute_instance" "bastion" {
   name = "bastion-windows"
   machine_type = local.machine-type
 
-  tags = ["bastion-windows"]
+  tags = ["bastion-windows", "rdp"]
 
   boot_disk {
     initialize_params {


### PR DESCRIPTION
This PR adds the missing `rdp` tag for bastion-windows. Closes #107. 